### PR TITLE
API-2148: updates to ruby client

### DIFF
--- a/ox3client.rb
+++ b/ox3client.rb
@@ -40,7 +40,7 @@ class OX3APIClient < OAuth::Consumer
     http.open_timeout =  5 * 60
     http.read_timeout = 15 * 60
     params = Hash.new
-    params['Content-Type'] = 'application/x-www-form-urlencoded'
+    params['Content-Type'] = 'application/json'
     params['Cookie'] = 'openx3_access_token=' + @acccess_token.token + '; domain=' + get_domain + '; path=/'
     prefix = @version == 'v1' ? "/ox/3.0" : "/ox/4.0"
     response = http.request yield prefix, params

--- a/ox3client.rb
+++ b/ox3client.rb
@@ -42,7 +42,7 @@ class OX3APIClient < OAuth::Consumer
     params = Hash.new
     params['Content-Type'] = 'application/json'
     params['Cookie'] = 'openx3_access_token=' + @acccess_token.token + '; domain=' + get_domain + '; path=/'
-    prefix = @version == 'v1' ? "/ox/3.0" : "/ox/4.0"
+    prefix = "/ox/4.0"
     response = http.request yield prefix, params
     response.body
   end
@@ -58,9 +58,26 @@ class OX3APIClient < OAuth::Consumer
   end
   
   def post(path, body = {})
+    if body.is_a?(Hash)
+      body = JSON.dump(body)
+    end
     perform_request do |prefix, params|
       self.create_http_request(
         :post, 
+        prefix + path,
+        body,
+        params
+      )
+    end
+  end
+  
+  def put(path, body = {})
+    if body.is_a?(Hash)
+      body = JSON.dump(body)
+    end
+    perform_request do |prefix, params|
+      self.create_http_request(
+        :put, 
         prefix + path,
         body,
         params
@@ -79,7 +96,7 @@ class OX3APIClient < OAuth::Consumer
   end
   
   def logoff
-    delete "/a/session"
+    get "/login/logout"
   end
 ################################################################################################################
 
@@ -129,19 +146,19 @@ private
   
   def validate_session
 =begin
-    path = @version == 'v1' ? "/ox/3.0/a/session/validate" : "/ox/4.0/session"
-    method = @version == 'v1' ? :put : :get
+    path = "/ox/4.0/session"
+    method = :get
     response = self.request(method.to_sym, @site + path, nil, {}, nil,
       {
-        'Content-Type' => 'application/x-www-form-urlencoded',
+        'Content-Type' => 'application/json',
         'Cookie' => 'openx3_access_token=' + @acccess_token.token + '; domain=' + get_domain + '; path=/'
       }
     )
 =end
     response = perform_request do |prefix, params|
       self.create_http_request(
-        @version == 'v1' ? :put : :get, 
-        prefix + (@version == 'v1' ? "/a/session/validate" : "/session"),
+        :get, 
+        prefix + "/session",
         nil,
         params
       )

--- a/test.rb
+++ b/test.rb
@@ -12,25 +12,26 @@ realm = ''
 site_url = ''
 
 ox3 = OX3APIClient.new(email, password, site_url, consumer_key, consumer_secret, realm)
-puts ox3.get('/a/site')
+puts ox3.get('/site')
 
-site = ox3.post('/a/site/12345',
-  {'id' => 12345, 'name' => 'SiteName', 'url' => 'http://www.sample.com', 'status' => 'Active'}
+# Create site
+site = ox3.post('/site',
+  {'name' => "SiteName ##{Random.rand(1000)}",
+   'url' => 'http://www.sample.com',
+   'account_uid' => '60000028-accf-fff1-8123-0c9a66', # uid of your publisher account
+   'status' => 'Active'}
 )
 puts site
-site = JSON.parse(ox3.get('/a/site/12345'))
+
+# Update site
+site_uid = '20000001-e000-fff1-8123-0c9a66'
+site = ox3.put("/site/#{site_uid}",
+  {'name' => "Updated Name for Site #{site_uid}", 'url' => 'http://www.sample.com'}
+)
 puts site
-puts site['name']
 
+# Check that the site's name was updated
+site = JSON.parse(ox3.get("/site/#{site_uid}"))
+puts site
+puts site[0]['name']
 
-##################
-#  OpenX API v1
-##################
-ox3v1 = OX3APIClient.new(email, password, site_url, consumer_key, consumer_secret, realm, 'v1')
-puts ox3v1.get('/a/account')
-
-##################
-#  OpenX API v2
-##################
-ox3v2 = OX3APIClient.new(email, password, site_url, consumer_key, consumer_secret, realm, 'v2')
-puts JSON.parse(ox3v2.get('/account'))['objects']


### PR DESCRIPTION
These updates allow the Ruby API client to work with API v2.
They also remove support for v1, which is no longer available.